### PR TITLE
Storing templates and modules in moduleRegistry and templateRegistry needed for HMR.

### DIFF
--- a/dist/commonjs/fuse-box-aurelia-loader.d.ts
+++ b/dist/commonjs/fuse-box-aurelia-loader.d.ts
@@ -3,6 +3,7 @@ export declare class FuseBoxAureliaLoader extends Loader {
     textPluginName: string;
     loaderPlugins: any;
     moduleRegistry: any;
+    templateRegistry: any;
     templateLoader: any;
     constructor();
     useTemplateLoader(templateLoader: any): void;

--- a/dist/commonjs/fuse-box-aurelia-loader.js
+++ b/dist/commonjs/fuse-box-aurelia-loader.js
@@ -78,6 +78,7 @@ var FuseBoxAureliaLoader = (function (_super) {
         return this._import(this.applyPluginToUrl(url, 'template-registry-entry')).then(function (template) {
             _this.moduleRegistry[url] = template;
             _this.templateRegistry[url] = template;
+            return template;
         });
     };
     FuseBoxAureliaLoader.prototype.loadText = function (url) {

--- a/dist/commonjs/fuse-box-aurelia-loader.js
+++ b/dist/commonjs/fuse-box-aurelia-loader.js
@@ -40,6 +40,7 @@ var FuseBoxAureliaLoader = (function (_super) {
         _this.textPluginName = 'text';
         _this.loaderPlugins = Object.create(null);
         _this.moduleRegistry = Object.create(null);
+        _this.templateRegistry = Object.create(null);
         _this.useTemplateLoader(new aurelia_loader_default_1.TextTemplateLoader());
         var that = _this;
         _this.addPlugin('template-registry-entry', {
@@ -71,8 +72,13 @@ var FuseBoxAureliaLoader = (function (_super) {
     FuseBoxAureliaLoader.prototype.loadTemplate = function (url) {
         var _this = this;
         debugPrint('info', 'loadTemplate => ', arguments);
-        return this._import(this.applyPluginToUrl(url, 'template-registry-entry'))
-            .then(function (template) { return _this.moduleRegistry[url] = template; });
+        if (this.templateRegistry[url]) {
+            return this.templateRegistry[url];
+        }
+        return this._import(this.applyPluginToUrl(url, 'template-registry-entry')).then(function (template) {
+            _this.moduleRegistry[url] = template;
+            _this.templateRegistry[url] = template;
+        });
     };
     FuseBoxAureliaLoader.prototype.loadText = function (url) {
         debugPrint('info', 'loadText => ', arguments);

--- a/dist/commonjs/fuse-box-aurelia-loader.js
+++ b/dist/commonjs/fuse-box-aurelia-loader.js
@@ -69,8 +69,10 @@ var FuseBoxAureliaLoader = (function (_super) {
         return Promise.all(loads);
     };
     FuseBoxAureliaLoader.prototype.loadTemplate = function (url) {
+        var _this = this;
         debugPrint('info', 'loadTemplate => ', arguments);
-        return this._import(this.applyPluginToUrl(url, 'template-registry-entry'));
+        return this._import(this.applyPluginToUrl(url, 'template-registry-entry'))
+            .then(function (template) { return _this.moduleRegistry[url] = template; });
     };
     FuseBoxAureliaLoader.prototype.loadText = function (url) {
         debugPrint('info', 'loadText => ', arguments);
@@ -85,6 +87,7 @@ var FuseBoxAureliaLoader = (function (_super) {
         debugPrint('info', 'loadModule => ', arguments);
         var module = this.loadWithFusebox(this.findFuseBoxPath(id));
         module = ensureOriginOnExports(module, id);
+        this.moduleRegistry[id] = module;
         return Promise.resolve(module);
     };
     FuseBoxAureliaLoader.prototype.addPlugin = function (pluginName, implementation) {

--- a/dist/commonjs/fuse-box-aurelia-loader.js
+++ b/dist/commonjs/fuse-box-aurelia-loader.js
@@ -73,7 +73,7 @@ var FuseBoxAureliaLoader = (function (_super) {
         var _this = this;
         debugPrint('info', 'loadTemplate => ', arguments);
         if (this.templateRegistry[url]) {
-            return this.templateRegistry[url];
+            return Promise.resolve(this.templateRegistry[url]);
         }
         return this._import(this.applyPluginToUrl(url, 'template-registry-entry')).then(function (template) {
             _this.moduleRegistry[url] = template;

--- a/src/fuse-box-aurelia-loader.ts
+++ b/src/fuse-box-aurelia-loader.ts
@@ -133,7 +133,8 @@ export class FuseBoxAureliaLoader extends Loader {
   */
   public loadTemplate(url: any): Promise<any> {
     debugPrint('info', 'loadTemplate => ', arguments);
-    return this._import(this.applyPluginToUrl(url, 'template-registry-entry'));
+    return this._import(this.applyPluginToUrl(url, 'template-registry-entry'))
+      .then((template: any) => this.moduleRegistry[url] = template);
   }
 
 
@@ -165,6 +166,7 @@ export class FuseBoxAureliaLoader extends Loader {
     debugPrint('info', 'loadModule => ', arguments);
     let module = this.loadWithFusebox(this.findFuseBoxPath(id));
     module = ensureOriginOnExports(module, id);
+    this.moduleRegistry[id] = module;
     return Promise.resolve(module);
   }
 

--- a/src/fuse-box-aurelia-loader.ts
+++ b/src/fuse-box-aurelia-loader.ts
@@ -67,6 +67,7 @@ export class FuseBoxAureliaLoader extends Loader {
   public textPluginName = 'text';
   public loaderPlugins = Object.create(null);
   public moduleRegistry: any;
+  public templateRegistry: any;
   public templateLoader: any;
 
 
@@ -76,6 +77,7 @@ export class FuseBoxAureliaLoader extends Loader {
   constructor() {
     super();
     this.moduleRegistry = Object.create(null);
+    this.templateRegistry = Object.create(null);
     this.useTemplateLoader(new TextTemplateLoader());
 
     let that = this;
@@ -133,8 +135,13 @@ export class FuseBoxAureliaLoader extends Loader {
   */
   public loadTemplate(url: any): Promise<any> {
     debugPrint('info', 'loadTemplate => ', arguments);
-    return this._import(this.applyPluginToUrl(url, 'template-registry-entry'))
-      .then((template: any) => this.moduleRegistry[url] = template);
+    if(this.templateRegistry[url]) {
+      return this.templateRegistry[url];
+    }
+    return this._import(this.applyPluginToUrl(url, 'template-registry-entry')).then((template: any) => {
+      this.moduleRegistry[url] = template;
+      this.templateRegistry[url] = template;
+    });
   }
 
 

--- a/src/fuse-box-aurelia-loader.ts
+++ b/src/fuse-box-aurelia-loader.ts
@@ -141,6 +141,7 @@ export class FuseBoxAureliaLoader extends Loader {
     return this._import(this.applyPluginToUrl(url, 'template-registry-entry')).then((template: any) => {
       this.moduleRegistry[url] = template;
       this.templateRegistry[url] = template;
+      return template;
     });
   }
 

--- a/src/fuse-box-aurelia-loader.ts
+++ b/src/fuse-box-aurelia-loader.ts
@@ -136,7 +136,7 @@ export class FuseBoxAureliaLoader extends Loader {
   public loadTemplate(url: any): Promise<any> {
     debugPrint('info', 'loadTemplate => ', arguments);
     if(this.templateRegistry[url]) {
-      return this.templateRegistry[url];
+      return Promise.resolve(this.templateRegistry[url]);
     }
     return this._import(this.applyPluginToUrl(url, 'template-registry-entry')).then((template: any) => {
       this.moduleRegistry[url] = template;


### PR DESCRIPTION
To be able to make HMR work, the modules must be stored in the moduleRegistry. The aurelia-hot-module-replacement package makes use of that. 
The module registry was created, but no modules where ever added to it.